### PR TITLE
Clarification of keybinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ You might want to add a keybinding in your `.tmux.conf` for toggling panes synch
 ```
 bind-key = set-window-option synchronize-panes
 ```
+This example assigns the `=` key.
 
 # Usage
 


### PR DESCRIPTION
I just had a conversation with a co-worker and it was unclear that `=` was the key being assigned here and not being used as an assignment character. The initial thought was that `set-window-option synchronize-panes` was being assigned to `bind-key` and there was confusion about how an actual *key* was being assigned here.