### PR TITLE
When reusing an existing client, don't detach when ssh finishes

### DIFF
--- a/tmux-cssh
+++ b/tmux-cssh
@@ -121,6 +121,7 @@ fi
 
 if [ -n "${TMUX}" ]; then
   # We are in a tmux, just switch to the new session
+  tmux set-option -t "${tmux_session}" detach-on-destroy no-detached
   tmux switch-client -t "${tmux_session}"
 else
   # We are NOT in a tmux, attach to the new session


### PR DESCRIPTION
Previously, when running tmux-cssh from an existing session, it would reuse the current client. This is reasonable; nesting tmux sessions is generally not a good idea. However, when the ssh commands finished, the session would be destroyed, and the client would automatically detach, closing the terminal. That makes it hard to understand what happened, especially when running non-interactive commands with `-o RemoteCommand`.

Tell tmux not to detach in this case. `set-option` is automatically scoped to the target session, so this does not affect other sessions.

Use `no-detached`, not `on` or `attach-client -f no-detach-on-destroy`, because there may be another terminal open that has activity before the cssh session ends. We can't guarantee that tmux will choose the right (previous) session, but we can make it more likely by filtering to only detached sessions.

See https://man.openbsd.org/tmux#detach-on-destroy for documentation.